### PR TITLE
Unicode string support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://repo.nwie.net:8080/nexus/content/groups/rubygems/'
+source 'https://rubygems.org'
 
 gem 'rspec'
 gem 'java'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    java (0.0.2)
+    nexus (1.4.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  java
+  nexus
+  rspec
+
+BUNDLED WITH
+   2.0.2

--- a/lib/orc_file_writer.rb
+++ b/lib/orc_file_writer.rb
@@ -41,8 +41,8 @@ class OrcFileWriter
             # hive needs date formated as number of days since epoch (01/01/1970)
             data_for_column = (value - Date.new(1970, 1, 1)).to_i
           when :string
-            orc_row.cols[index].initBuffer(value.to_s.bytes.to_a.size)
-            data_for_column = value.to_s.bytes
+            orc_row.cols[index].initBuffer(value.to_s.to_java_bytes.to_a.size)
+            data_for_column = value.to_s.to_java_bytes
           else
             raise ArgumentError, "column data type #{data_type} not defined"
         end

--- a/orcfile.gemspec
+++ b/orcfile.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'orcfile'
-  spec.version = '1.0.0'
+  spec.version = '1.0.1'
   spec.authors = ['Andrew Shane']
   spec.email = ['ashane9@gmail.com']
   spec.metadata['source_code_uri'] = 'https://github.com/ashane9/orc_file'

--- a/spec/orc_file_spec.rb
+++ b/spec/orc_file_spec.rb
@@ -354,7 +354,7 @@ describe OrcFile do
       end
 
       it 'will write the single row to an orc file' do
-        expect(orc_file_writer.writer.number_of_rows).to eq 3
+        expect(orc_file_writer.writer.number_of_rows).to eq @data_set.size
         expect(File).to exist @orc_file_path
       end
     end
@@ -443,7 +443,7 @@ describe OrcFile do
       end
 
       it 'will read the row from an orc file' do
-        expect(@orc_file_reader.reader.number_of_rows).to eq 3
+        expect(@orc_file_reader.reader.number_of_rows).to eq @data_set.size
       end
 
     end

--- a/spec/orc_file_spec.rb
+++ b/spec/orc_file_spec.rb
@@ -19,6 +19,8 @@ describe OrcFile do
                  :column5 => 1000.01.to_d, :column6 => 0.0005, :column7 => 'the string column'},
                 {:column1 => 52, :column2 => DateTime.now, :column3 => Time.now, :column4 => Date.today,
                  :column5 => 500.01.to_d, :column6 => 0.1005, :column7 => 'row 3'},
+                 {:column1 => 9714, :column2 => DateTime.now, :column3 => Time.now, :column4 => Date.today,
+                  :column5 => 8208.9234.to_d, :column6 => 1973.35, :column7 => 'unicode 安装管理程序'},
                 {:column1 => nil, :column2 => nil, :column3 => nil, :column4 => nil,
                  :column5 => nil, :column6 => nil, :column7 => nil}]
 


### PR DESCRIPTION
Uses `String#to_java_bytes` to properly encode the Unicode characters for string types for the underlying Java libraries.  This will prevent range errors due to `String#to_bytes` treating the string as unsigned integer bytes.  (Note: ASCII-compatible bytes are treated identically in both situations.)

Closes #2.